### PR TITLE
Fixed error in config parsing that caused header errors in HTTP requests

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ function resolveApiKey() {
     return fs.readFileSync(process.env.NOMOS_API_KEY_FILE).trim();
   }
 
-  return process.env.NOMOS_API_KEY.trim() || "";
+  return (process.env.NOMOS_API_KEY || "").trim();
 }
 
 const NOMOS_API_KEY = resolveApiKey();

--- a/src/config.js
+++ b/src/config.js
@@ -6,10 +6,10 @@ const NOMOS_BASE_URI = process.env.NOMOS_BASE_URI || "https://membership.vanhack
 
 function resolveApiKey() {
   if (process.env.NOMOS_API_KEY_FILE) {
-    return fs.readFileSync(process.env.NOMOS_API_KEY_FILE);
+    return fs.readFileSync(process.env.NOMOS_API_KEY_FILE).trim();
   }
 
-  return process.env.NOMOS_API_KEY || "";
+  return process.env.NOMOS_API_KEY.trim() || "";
 }
 
 const NOMOS_API_KEY = resolveApiKey();


### PR DESCRIPTION
Trailing newline in the nomos_api_key file would cause the NOMOS request to fail.